### PR TITLE
Added is_covariance=False in coadd to prevent bug.

### DIFF
--- a/sacc/coadd.py
+++ b/sacc/coadd.py
@@ -35,7 +35,7 @@ def coadd(sacclist):
             otr.Nz+=ctr.Nz
         
     newmean=np.dot(la.inv(sw),swd)
-    outsacc.precision=Precision(sw)
+    outsacc.precision=Precision(sw, is_covariance=False)
     outsacc.mean=MeanVec(newmean)
     return outsacc
 

--- a/sacc/tracer.py
+++ b/sacc/tracer.py
@@ -122,7 +122,7 @@ class Tracer(object):
             dt.append(("DNz_"+str(i),'f4'))
         #TOM: TODO - wtf is going on here?
         for k,c in self.extra_cols.items():
-            #dt.append((k.encode("ascii"),c.dtype))
+            # dt.append((k.encode("ascii"),c.dtype))
             dt.append((k,c.dtype))
             #dt.append(("b",c.dtype))
         


### PR DESCRIPTION
This PR explicitly adds the flag is_covariance=False in coadd.py to match the changes in precision.py, where by default is_covariance=True. This fixes a bug that after coaddition all precision/covariance matrices are switched.