### PR TITLE
Add log-top-hat window function objects

### DIFF
--- a/sacc/__init__.py
+++ b/sacc/__init__.py
@@ -1,5 +1,5 @@
 from .sacc import Sacc, DataPoint
-from .windows import Window, TopHatWindow
+from .windows import Window, TopHatWindow, LogTopHatWindow
 from .data_types import standard_types, parse_data_type_name, build_data_type_name
 from .tracers import BaseTracer
 from .covariance import BaseCovariance

--- a/sacc/windows.py
+++ b/sacc/windows.py
@@ -166,7 +166,7 @@ class LogTopHatWindow(TopHatWindow, window_type='LogTopHat'):
 
     This object is the same as the TopHat form, except that in between
     the min and max values it is assumed to be constant in the log of the
-    argument.  The difference arises when this objects is used elsewhere.
+    argument.  The difference arises when this object is used elsewhere.
     """
     pass
 

--- a/sacc/windows.py
+++ b/sacc/windows.py
@@ -160,6 +160,16 @@ class TopHatWindow(BaseWindow, window_type='TopHat'):
         return {row['id']: cls(row['min'], row['max']) for row in table}
 
 
+
+class LogTopHatWindow(TopHatWindow, window_type='LogTopHat'):
+    """A window function that is log-constant between two values.
+
+    This object is the same as the TopHat form, except that in between
+    the min and max values it is assumed to be constant in the log of the
+    argument.  The difference arises when this objects is used elsewhere.
+    """
+    pass
+
 class Window(BaseWindow, window_type='Standard'):
     """The Window class defines a tabulated window function.
 

--- a/test/test_sacc2.py
+++ b/test/test_sacc2.py
@@ -246,3 +246,25 @@ def test_parse_data_names():
         sources, props, stat, sub = sacc.parse_data_type_name(name)
         name2 = sacc.build_data_type_name(sources, props, stat, sub)
         assert name == name2
+
+def test_window():
+    W1 = []
+    for i in range(10):
+        w = sacc.TopHatWindow(i*10, (i+1)*10)
+        W1.append(w)
+    tables = sacc.TopHatWindow.to_tables(W1)
+    W2 = sacc.TopHatWindow.from_tables(tables)
+    for w1 in W1:
+        w2 = W2[id(w1)]
+        assert (w1.min, w1.max) == (w2.min, w2.max)
+
+def test_log_window():
+    W1 = []
+    for i in range(10):
+        w = sacc.LogTopHatWindow(i*10, (i+1)*10)
+        W1.append(w)
+    tables = sacc.LogTopHatWindow.to_tables(W1)
+    W2 = sacc.LogTopHatWindow.from_tables(tables)
+    for w1 in W1:
+        w2 = W2[id(w1)]
+        assert (w1.min, w1.max) == (w2.min, w2.max)


### PR DESCRIPTION
This PR adds window function objects that are flat in log(x) instead of x.

They are implemented as a subclass of TopHatWindow, since the data storage for the two cases is identical (just need to save min and max values) except for a single name tag.

If we add projection methods later then it will need to be different between the two.