### PR TITLE
Expose tracers_later in add_ell_cl and add_theta_xi

### DIFF
--- a/sacc/sacc.py
+++ b/sacc/sacc.py
@@ -857,7 +857,7 @@ class Sacc:
         """
         return self._get_2pt(data_type, tracer1, tracer2, return_cov, 'theta')
 
-    def _add_2pt(self, data_type, tracer1, tracer2, x, tag_val, tag_name, window):
+    def _add_2pt(self, data_type, tracer1, tracer2, x, tag_val, tag_name, window, tracers_later):
         """
         Internal method for adding 2pt data points.
         Copes with multiple values for the parameters
@@ -867,7 +867,7 @@ class Sacc:
             t = {tag_name: float(tag_val)}
             if window is not None:
                 t['window'] = window
-            self.add_data_point(data_type, (tracer1, tracer2), x, **t)
+            self.add_data_point(data_type, (tracer1, tracer2), x, tracers_later=tracers_later, **t)
             return
         # multiple ell/theta values but same bin
         elif np.isscalar(tracer1):
@@ -877,10 +877,10 @@ class Sacc:
                 raise ValueError(f"Length of inputs do not match in added 2pt data ({n1},{n2})")
             if window is None:
                 for tag_i, x_i in zip(tag_val, x):
-                    self._add_2pt(data_type, tracer1, tracer2, x_i, tag_i, tag_name, window)
+                    self._add_2pt(data_type, tracer1, tracer2, x_i, tag_i, tag_name, window, tracers_later)
             else:
                 for tag_i, x_i, w_i in zip(tag_val, x, window):
-                    self._add_2pt(data_type, tracer1, tracer2, x_i, tag_i, tag_name, w_i)
+                    self._add_2pt(data_type, tracer1, tracer2, x_i, tag_i, tag_name, w_i, tracers_later)
         # multiple bin values
         elif np.isscalar(data_type):
             n1 = len(x)
@@ -891,10 +891,10 @@ class Sacc:
                 raise ValueError(f"Length of inputs do not match in added 2pt data ({n1}, {n2}, {n3}, {n4})")
             if window is None:
                 for b1, b2, tag_i, x_i in zip(tracer1, tracer2, tag_val, x):
-                    self._add_2pt(data_type, b1, b2, x_i, tag_i, tag_name, window)
+                    self._add_2pt(data_type, b1, b2, x_i, tag_i, tag_name, window, tracers_later)
             else:
                 for b1, b2, tag_i, x_i, w_i in zip(tracer1, tracer2, tag_val, x, window):
-                    self._add_2pt(data_type, b1, x_i, tag_i, tag_name, w_i)
+                    self._add_2pt(data_type, b1, x_i, tag_i, tag_name, w_i, tracers_later)
         # multiple data point values
         else:
             n1 = len(x)
@@ -906,12 +906,12 @@ class Sacc:
                 raise ValueError(f"Length of inputs do not match in added 2pt data ({n1}, {n2}, {n3}, {n4}, {n5})")
             if window is None:
                 for d, b1, b2, tag_i, x_i in zip(data_type, tracer1, tracer2, tag_val, x):
-                    self._add_2pt(d, b1, b2, x_i, tag_i, tag_name, window)
+                    self._add_2pt(d, b1, b2, x_i, tag_i, tag_name, window, tracers_later)
             else:
                 for d, b1, b2, tag_i, x_i, w_i in zip(data_type, tracer1, tracer2, tag_val, x, window):
-                    self._add_2pt(d, b1, b2, x_i, tag_i, tag_name, w_i)
+                    self._add_2pt(d, b1, b2, x_i, tag_i, tag_name, w_i, tracers_later)
 
-    def add_ell_cl(self, data_type, tracer1, tracer2, ell, x, window=None):
+    def add_ell_cl(self, data_type, tracer1, tracer2, ell, x, window=None, tracers_later=False):
         """
         Add a series of 2pt Fourier space data points, either
         individually or as a group.
@@ -937,14 +937,18 @@ class Sacc:
             Optional window object describing the window function
             of the data point.
 
+        tracers_later: bool
+            Optional.  If False (the default), complain if n(z) tracers have 
+            not yet been defined. Otherwise, suppress this warning
+
         Returns
         -------
         None
 
         """
-        self._add_2pt(data_type, tracer1, tracer2, x, ell, 'ell', window)
+        self._add_2pt(data_type, tracer1, tracer2, x, ell, 'ell', window, tracers_later)
 
-    def add_theta_xi(self, data_type, tracer1, tracer2, theta, x, window=None):
+    def add_theta_xi(self, data_type, tracer1, tracer2, theta, x, window=None, tracers_later=False):
         """
         Add a series of 2pt real space data points, either
         individually or as a group.
@@ -970,9 +974,13 @@ class Sacc:
             Optional window object describing the window function
             of the data point.
 
+        tracers_later: bool
+            Optional.  If False (the default), complain if n(z) tracers have 
+            not yet been defined. Otherwise, suppress this warning
+
         Returns
         -------
         None
 
         """
-        self._add_2pt(data_type, tracer1, tracer2, x, theta, 'theta', window)
+        self._add_2pt(data_type, tracer1, tracer2, x, theta, 'theta', window, tracers_later)

--- a/test/test_sacc2.py
+++ b/test/test_sacc2.py
@@ -2,6 +2,7 @@ import sacc
 import sacc.data_types
 import numpy as np
 import scipy.linalg
+import pytest
 
 def test_construct():
     s = sacc.Sacc()
@@ -15,6 +16,19 @@ def test_construct():
         ee = 0.1 * i
         tracers = ('source_0', 'source_0')
         s.add_data_point(sacc.standard_types.galaxy_shear_cl_ee, tracers, ee, ell=10.0*i)
+
+
+def test_tracers_later():
+    s = sacc.Sacc()
+
+    with pytest.raises(ValueError):
+        tracers = ('source_0', 'source_0')
+        s.add_data_point(sacc.standard_types.galaxy_shear_cl_ee, tracers, 0.0, ell=1)
+
+    s = sacc.Sacc()
+
+    tracers = ('source_0', 'source_0')
+    s.add_data_point(sacc.standard_types.galaxy_shear_cl_ee, tracers, 0.0, tracers_later=True, ell=1)
 
 
 def test_full_cov():


### PR DESCRIPTION
This PR exposes the parameter tracers_later, which is useful when constructing data files before you have n(z) information, to the helper methods for adding xi(theta) or C_ell values.