### PR TITLE
Add test and fix for bug in block diag covs

### DIFF
--- a/sacc/covariance.py
+++ b/sacc/covariance.py
@@ -382,7 +382,7 @@ class BlockDiagonalCovariance(BaseCovariance, cov_type='block'):
             sub_blocks = []
             for block, sz in zip(self.blocks, self.block_sizes):
                 e = s + sz
-                m = indices[(indices >= s) & (indices < e)]
+                m = indices[(indices >= s) & (indices < e)] - s
                 sub_blocks.append(block[m][:, m])
                 s += sz
             return self.__class__(sub_blocks)

--- a/test/test_sacc2.py
+++ b/test/test_sacc2.py
@@ -382,6 +382,16 @@ def test_cutting_block_cov():
     assert C2.size == len(ind)
     assert np.allclose(C2.get_block(ind), covmat[0])
 
+def test_cutting_block_cov2():
+    covmat = [np.random.uniform(size=(50, 50)),
+              np.random.uniform(size=(100, 100)),
+              np.random.uniform(size=(150, 150))]
+    C = sacc.covariance.BaseCovariance.make(covmat)
+    ind = list(range(50,150))
+    C2 = C.keeping_indices(np.arange(50,150))
+    assert C2.size == len(ind)
+    assert np.allclose(C2.get_block(range(100)), covmat[1])
+
 
 def test_cutting_full_cov():
     covmat = np.random.uniform(size=(100, 100))


### PR DESCRIPTION
@empEvil has found an indexing bug when cutting block-diagonal covariances.  It's similar to one found earlier, with the same fix.  This seems to be the only other instance of it.

This adds a test and fix.