### PR TITLE
Deprecated numpy alias

### DIFF
--- a/sacc/sacc.py
+++ b/sacc/sacc.py
@@ -268,7 +268,7 @@ class Sacc:
         indices = np.array(indices)
 
         # Convert integer masks to booleans
-        if indices.dtype != np.bool:
+        if indices.dtype != bool:
             indices = self._indices_to_bool(indices)
 
         self.data = [d for i, d in enumerate(self.data) if indices[i]]


### PR DESCRIPTION
Since version 1.20, `numpy` has deprecated aliases for builtin types (see https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations). 