### PR TITLE
Fix deprecation warning and move to numpy 1.20

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2019 The SACC Developers
+Copyright 2019-2022 The SACC Developers
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 scipy
-numpy>=1.16
+numpy>=1.20
 numpydoc
 astropy

--- a/sacc/sacc.py
+++ b/sacc/sacc.py
@@ -298,7 +298,7 @@ class Sacc:
         indices = np.array(indices)
 
         # Convert integer masks to booleans
-        if indices.dtype != np.bool:
+        if indices.dtype != bool:
             indices = self._indices_to_bool(indices)
 
         # Get the mask method to do the actual work


### PR DESCRIPTION
This commit applies the fix recommended in the deprecation warning message.

As a result, this also moves us to requiring `numpy` 1.20 or newer.