### PR TITLE
Get data types associated to a specific tracer combination

### DIFF
--- a/sacc/sacc.py
+++ b/sacc/sacc.py
@@ -610,14 +610,8 @@ class Sacc:
         data_types: list of strings
             A list of the string data types in the data set
         """
-        data_types = unique_list(d.data_type for d in self.data)
-
-        if tracers is not None:
-            output = []
-            for dt in data_types:
-                if len(self.indices(data_type=dt, tracers=tracers)) != 0:
-                    output.append(dt)
-            data_types = output
+        data_types = unique_list(d.data_type for d in self.data if
+                                 ((tracers is None) or (d.tracers == tracers)))
 
         return data_types
 

--- a/sacc/sacc.py
+++ b/sacc/sacc.py
@@ -595,16 +595,31 @@ class Sacc:
         indices = self.indices(data_type=data_type, tracers=tracers, **select)
         return self.mean[indices]
 
-    def get_data_types(self):
+    def get_data_types(self, tracers=None):
         """
         Get a list of the different data types stored in the Sacc
+
+        Parameters
+        ----------
+        tracers: tuple
+            Select only data types which match this tracer combination.
+            If None (the default) then match any tracer combinations.
 
         Returns
         --------
         data_types: list of strings
             A list of the string data types in the data set
         """
-        return unique_list(d.data_type for d in self.data)
+        data_types = unique_list(d.data_type for d in self.data)
+
+        if tracers is not None:
+            output = []
+            for dt in data_types:
+                if len(self.indices(data_type=dt, tracers=tracers)) != 0:
+                    output.append(dt)
+            data_types = output
+
+        return data_types
 
     def get_tracer(self, name):
         """

--- a/test/test_sacc2.py
+++ b/test/test_sacc2.py
@@ -81,6 +81,17 @@ def test_data_type_warning():
                          0.1, ell=10.)
 
 
+def test_get_data_types():
+    s = get_filled_sacc()
+    dt1 = [sacc.standard_types.count, sacc.standard_types.galaxy_shear_cl_bb,
+            sacc.standard_types.galaxy_shear_cl_ee]
+    dt2 = s.get_data_types()
+    assert sorted(dt1) == sorted(dt2)
+
+    dt2 = s.get_data_types(tracers=('source_0', 'source_1'))
+    assert [sacc.standard_types.galaxy_shear_cl_bb] == dt2
+
+
 def test_construct():
     s = sacc.Sacc()
 


### PR DESCRIPTION
I have added the option to return the data types specific to some tracer combination. This is something I was doing in TJPCov to loop over the data types (see e.g https://github.com/LSSTDESC/TJPCov/blob/e854d808487a0c857b4e6200f5797d841232ba7f/tjpcov/covariance_builder.py#L582).