### PR TITLE
Tiny bug in `remove_tracers`

### DIFF
--- a/sacc/sacc.py
+++ b/sacc/sacc.py
@@ -665,6 +665,7 @@ class Sacc:
             for tri in trs:
                 if tri in names:
                     self.remove_selection(tracers=trs)
+                    break
 
         for name in names:
             del self.tracers[name]


### PR DESCRIPTION
If a tracer combination contains two tracers to be removed, sacc will try to remove that tracer combination twice, triggering an "empty index" warning that could throw people off. I think this fixes it.