### PR TITLE
raise error if covariance exist & not overwrite

### DIFF
--- a/sacc/sacc.py
+++ b/sacc/sacc.py
@@ -216,7 +216,7 @@ class Sacc:
         -------
         None
         """
-        if self.has_covariance() and (overwrite is False):
+        if self.has_covariance() and not overwrite:
             raise RuntimeError("This sacc file already contains a covariance"
                                "matrix. Use overwrite=True if you want to "
                                "replace it for the new one")
@@ -232,6 +232,7 @@ class Sacc:
                              f"Should be {expected_size} but is {cov.size}")
 
         self.covariance = cov
+
     def has_covariance(self):
         """ Return whether or not this data set has a covariance attached to it
 

--- a/sacc/sacc.py
+++ b/sacc/sacc.py
@@ -198,7 +198,7 @@ class Sacc:
         d = DataPoint(data_type, tracers, value, **tags)
         self.data.append(d)
 
-    def add_covariance(self, covariance):
+    def add_covariance(self, covariance, overwrite=False):
         """
         Once you have finished adding data points, add a covariance
         for the entire set.
@@ -208,11 +208,19 @@ class Sacc:
         covariance: array or list
             2x2 numpy array containing the covariance of the added data points
             OR a list of blocks
+        overwrite: bool
+            If True, it overwrites the stored covariance matrix with the given
+            one.
 
         Returns
         -------
         None
         """
+        if self.has_covariance() and (overwrite is False):
+            raise RuntimeError("This sacc file already contains a covariance"
+                               "matrix. Use overwrite=True if you want to "
+                               "replace it for the new one")
+
         if isinstance(covariance, BaseCovariance):
             cov = covariance
         else:
@@ -224,7 +232,6 @@ class Sacc:
                              f"Should be {expected_size} but is {cov.size}")
 
         self.covariance = cov
-
     def has_covariance(self):
         """ Return whether or not this data set has a covariance attached to it
 

--- a/test/test_sacc2.py
+++ b/test/test_sacc2.py
@@ -66,6 +66,18 @@ def get_filled_sacc():
     return s
 
 
+def test_add_covariance():
+    s = get_filled_sacc()
+    cov = np.ones((s.mean.size, s.mean.size))
+    s.add_covariance(cov)
+
+    with pytest.raises(RuntimeError):
+        s.add_covariance(cov)
+
+    s.add_covariance(0 * cov, overwrite=True)
+    assert np.all(s.covariance.covmat == 0 * cov)
+
+
 def test_quantity_warning():
     s = sacc.Sacc()
     with pytest.warns(UserWarning):


### PR DESCRIPTION
Closes #78. Basically, it does not allow you to add a new covariance if there is one already defined in the sacc file unless you pass the `overwrite=True` option