### PR TITLE
Always internally store and compare tracer types in lower case

### DIFF
--- a/sacc/tracers.py
+++ b/sacc/tracers.py
@@ -49,7 +49,7 @@ class BaseTracer:
         self.metadata = kwargs.pop('metadata', {})
 
     def __init_subclass__(cls, tracer_type):
-        cls._tracer_classes[tracer_type] = cls
+        cls._tracer_classes[tracer_type.lower()] = cls
         cls.tracer_type = tracer_type
 
     @classmethod
@@ -72,7 +72,7 @@ class BaseTracer:
         instance: Tracer object
             An instance of a Tracer subclass
         """
-        subclass = cls._tracer_classes[tracer_type]
+        subclass = cls._tracer_classes[tracer_type.lower()]
         obj = subclass(name, *args, **kwargs)
         return obj
 
@@ -135,7 +135,7 @@ class BaseTracer:
         """
         tracers = {}
         # Figure out the different subclasses that are present
-        subclass_names = unique_list(table.meta['SACCCLSS']
+        subclass_names = unique_list(table.meta['SACCCLSS'].lower()
                                      for table in table_list)
         subclasses = [cls._tracer_classes[name]
                       for name in subclass_names]
@@ -146,7 +146,7 @@ class BaseTracer:
         # it depends on the tracers class and how complicated it is.
         for name, subcls in zip(subclass_names, subclasses):
             subcls_table_list = [table for table in table_list
-                                 if table.meta['SACCCLSS'] == name]
+                                 if table.meta['SACCCLSS'].lower() == name]
             # and ask the subclass to read from those tables.
             tracers.update(subcls.from_tables(subcls_table_list))
         return tracers

--- a/test/test_sacc2.py
+++ b/test/test_sacc2.py
@@ -333,6 +333,13 @@ def test_nz_tracer():
     assert T1.metadata == md1
     assert T2.metadata == md2
 
+    # check that we can make a tracer using lower case
+    T3 = sacc.BaseTracer.make('nz', 'tracer2', z, Nz2,
+                              quantity='galaxy_shear',
+                              spin=2,
+                              metadata=md2)
+    assert T3.metadata == md2
+
     tables = sacc.BaseTracer.to_tables([T1, T2])
     D = sacc.BaseTracer.from_tables(tables)
 
@@ -358,7 +365,7 @@ def test_mixed_tracers():
                               quantity='galaxy_shear', metadata=md1)
 
     M1 = sacc.BaseTracer.make("Misc", "sample1", metadata=md2)
-    M2 = sacc.BaseTracer.make("Misc", "sample2", metadata=md3)
+    M2 = sacc.BaseTracer.make("mISC", "sample2", metadata=md3)
 
     tables = sacc.BaseTracer.to_tables([T1, M1, T2, M2])
     recovered = sacc.BaseTracer.from_tables(tables)
@@ -422,9 +429,9 @@ def test_keep_remove():
     z = np.arange(0., 1.0, 0.01)
     nz = (z-0.5)**2/0.1**2
     s.add_tracer('NZ', 'source_0', z, nz)
-    s.add_tracer('NZ', 'source_1', z, nz,
+    s.add_tracer('nZ', 'source_1', z, nz,
                  quantity='galaxy_shear', spin=2)
-    s.add_tracer('NZ', 'source_2', z, nz,
+    s.add_tracer('nz', 'source_2', z, nz,
                  quantity='cluster_density')
 
     for i in range(20):
@@ -751,7 +758,7 @@ def test_io_maps_bpws():
     # Tracer
     s.add_tracer('NZ', 'gc', z, nz)
     s.add_tracer('NuMap', 'cmbp', 2, nu, bandpass, ell, beam)
-    s.add_tracer('Map', 'sz', 0, ell, beam)
+    s.add_tracer('maP', 'sz', 0, ell, beam)
 
     # Window
     ells_large = np.arange(n_ell_large)
@@ -852,7 +859,7 @@ def test_io_qp():
     nz = np.expand_dims((z-0.5)**2/0.1**2, 0)
     ens = qp.Ensemble(qp.interp, data=dict(xvals=z, yvals=nz))
     ens.set_ancil(dict(modes = ens.mode(z)))
-    s.add_tracer('QPNZ', 'source_0', ens)
+    s.add_tracer('QpnZ', 'source_0', ens)
 
     for i in range(20):
         ee = 0.1 * i


### PR DESCRIPTION
I felt bad about the last PR breaking some user code. This should restore things so that users can
1) call `Sacc.add_tracer` using any case for the name
2) get the correct results even for legacy files.

It should still avoid adding second copies of tracers to files.