### PR TITLE
Issue/93/revert to radius tracer

### DIFF
--- a/examples/demo_sacc_for_clusters_N+M.ipynb
+++ b/examples/demo_sacc_for_clusters_N+M.ipynb
@@ -46,7 +46,9 @@
     "\n",
     "import sacc as sacc\n",
     "\n",
-    "os.environ['CLMM_MODELING_BACKEND'] = 'nc' # Need to use NumCosmo as CLMM's backend as well.\n",
+    "os.environ[\n",
+    "    \"CLMM_MODELING_BACKEND\"\n",
+    "] = \"nc\"  # Need to use NumCosmo as CLMM's backend as well.\n",
     "import clmm\n",
     "from clmm import Cosmology"
    ]
@@ -73,7 +75,7 @@
     "sigma8 = 0.8\n",
     "\n",
     "Ncm.cfg_init()\n",
-    "#cosmo = Nc.HICosmoDEXcdm() # not (yet) supported by CLMM --> using Nc.HICosmoDECpl() instead\n",
+    "# cosmo = Nc.HICosmoDEXcdm() # not (yet) supported by CLMM --> using Nc.HICosmoDECpl() instead\n",
     "cosmo = Nc.HICosmoDECpl()\n",
     "reion = Nc.HIReionCamb.new()\n",
     "prim = Nc.HIPrimPowerLaw.new()\n",
@@ -129,7 +131,7 @@
    "outputs": [],
    "source": [
     "# Define the sky area and the richness and redshift ranges\n",
-    "area = 5000. # deg2\n",
+    "area = 5000.0  # deg2\n",
     "lnRl = 0.0\n",
     "lnRu = 6.0\n",
     "zl = 0.2\n",
@@ -145,18 +147,26 @@
     ")\n",
     "\n",
     "# mean richness-mass relation parameters\n",
-    "cluster_m.param_set_by_name(\"mup0\", 3.15) # normalisation\n",
-    "cluster_m.param_set_by_name(\"mup1\", 0.86 / np.log(10)) # mass dependence, adapted to match the log10 definition used in NumCosmo\n",
-    "cluster_m.param_set_by_name(\"mup2\", -0.21 / np.log(10)) # redshift dependence, adapted to match the log10 definition used in NumCosmo\n",
+    "cluster_m.param_set_by_name(\"mup0\", 3.15)  # normalisation\n",
+    "cluster_m.param_set_by_name(\n",
+    "    \"mup1\", 0.86 / np.log(10)\n",
+    ")  # mass dependence, adapted to match the log10 definition used in NumCosmo\n",
+    "cluster_m.param_set_by_name(\n",
+    "    \"mup2\", -0.21 / np.log(10)\n",
+    ")  # redshift dependence, adapted to match the log10 definition used in NumCosmo\n",
     "# richness-mass scatter parameter\n",
-    "cluster_m.param_set_by_name(\"sigmap0\", 0.33) # normalisation\n",
-    "cluster_m.param_set_by_name(\"sigmap1\", -0.08 / np.log(10)) # mass dependence, adapted to match the log10 definition used in NumCosmo\n",
-    "cluster_m.param_set_by_name(\"sigmap2\", 0.03 / np.log(10)) # redshift dependence, adapted to match the log10 definition used in NumCosmo\n",
+    "cluster_m.param_set_by_name(\"sigmap0\", 0.33)  # normalisation\n",
+    "cluster_m.param_set_by_name(\n",
+    "    \"sigmap1\", -0.08 / np.log(10)\n",
+    ")  # mass dependence, adapted to match the log10 definition used in NumCosmo\n",
+    "cluster_m.param_set_by_name(\n",
+    "    \"sigmap2\", 0.03 / np.log(10)\n",
+    ")  # redshift dependence, adapted to match the log10 definition used in NumCosmo\n",
     "\n",
-    " \n",
+    "\n",
     "# Numcosmo Mass Function\n",
-    "# First, define the multiplicity function. \n",
-    "mulf = Nc.MultiplicityFuncTinker.new() # Tinker (2008)\n",
+    "# First, define the multiplicity function.\n",
+    "mulf = Nc.MultiplicityFuncTinker.new()  # Tinker (2008)\n",
     "mulf.set_linear_interp(True)  # This reproduces the linear interpolation done in CCL\n",
     "mulf.set_mdef(Nc.MultiplicityFuncMassDef.MEAN)\n",
     "mulf.set_Delta(200)\n",
@@ -169,9 +179,7 @@
     "ca = Nc.ClusterAbundance.new(hmf, None)\n",
     "\n",
     "# Number Counts object\n",
-    "ncount = Nc.DataClusterNCount.new(\n",
-    "    ca, \"NcClusterRedshiftNodist\", \"NcClusterMassAscaso\"\n",
-    ")\n",
+    "ncount = Nc.DataClusterNCount.new(ca, \"NcClusterRedshiftNodist\", \"NcClusterMassAscaso\")\n",
     "ca.prepare(cosmo, cluster_z, cluster_m)\n",
     "mset = Ncm.MSet.new_array([cosmo, cluster_z, cluster_m])\n",
     "\n",
@@ -180,7 +188,7 @@
     "\n",
     "ncount.catalog_save(\"ncount_rich.fits\", True)\n",
     "ncdata_fits = fits.open(\"ncount_rich.fits\")\n",
-    "ncdata_data = ncdata_fits[1].data \n",
+    "ncdata_data = ncdata_fits[1].data\n",
     "ncdata_Table = Table(ncdata_data)"
    ]
   },
@@ -234,7 +242,7 @@
     "    cluster_z, cluster_richness, cluster_logM, \"std\", bins=[z_edges, richness_edges]\n",
     ").statistic\n",
     "\n",
-    "var_mean_logM = std_logM**2 / cluster_counts \n",
+    "var_mean_logM = std_logM**2 / cluster_counts\n",
     "\n",
     "covariance = np.diag(\n",
     "    np.concatenate((cluster_counts.flatten(), var_mean_logM.flatten()))\n",
@@ -294,7 +302,7 @@
     "    s_count.add_data_point(\n",
     "        cluster_count, (survey_name, bin_z_label, bin_richness_label), int(counts)\n",
     "    )\n",
-    "    \n",
+    "\n",
     "for bin_mean_logM, (bin_z_label, bin_richness_label) in mean_logM_and_edges:\n",
     "    s_count.add_data_point(\n",
     "        cluster_mass,\n",
@@ -423,7 +431,7 @@
     "for counts, (bin_z_label, bin_richness_label) in counts_and_edges:\n",
     "    s_count2.add_data_point(\n",
     "        cluster_count, (survey_name, bin_z_label, bin_richness_label), int(counts)\n",
-    "    )\n"
+    "    )"
    ]
   },
   {
@@ -458,7 +466,9 @@
     "    bins=[z_edges, richness_edges],\n",
     ").statistic\n",
     "\n",
-    "radius_edges = clmm.make_bins(0.3, 6., nbins=6, method=\"evenlog10width\") # 6 radial bins log-spaced between 0.3 and 6 Mpc"
+    "radius_edges = clmm.make_bins(\n",
+    "    0.3, 6.0, nbins=6, method=\"evenlog10width\"\n",
+    ")  # 6 radial bins log-spaced between 0.3 and 6 Mpc"
    ]
   },
   {
@@ -482,14 +492,14 @@
     "radius_centers = []\n",
     "for i, radius_bin in enumerate(zip(radius_edges[:-1], radius_edges[1:])):\n",
     "    radius_lower, radius_upper = radius_bin\n",
-    "    radius_center = np.mean(radius_edges[i:i+1])\n",
+    "    radius_center = np.mean(radius_edges[i : i + 1])\n",
     "    radius_centers.append(radius_center)\n",
     "    bin_radius_label = f\"bin_radius_{i}\"\n",
     "    s_count2.add_tracer(\n",
     "        \"bin_radius\", bin_radius_label, radius_lower, radius_upper, radius_center\n",
     "    )\n",
     "    bin_radius_labels.append(bin_radius_label)\n",
-    "    \n",
+    "\n",
     "cluster_shear = sacc.standard_types.cluster_shear"
    ]
   },
@@ -509,15 +519,20 @@
    "outputs": [],
    "source": [
     "redshifts_masses_and_edges = zip(\n",
-    "    mean_z.flatten(), mean_logM.flatten(),itertools.product(bin_z_labels, bin_richness_labels))\n",
+    "    mean_z.flatten(),\n",
+    "    mean_logM.flatten(),\n",
+    "    itertools.product(bin_z_labels, bin_richness_labels),\n",
+    ")\n",
     "for redshift, log_mass, (bin_z_label, bin_richness_label) in redshifts_masses_and_edges:\n",
     "    mass = 10**log_mass\n",
     "    moo.set_mass(mass)\n",
     "    profile = moo.eval_excess_surface_density(radius_centers, redshift)\n",
-    "    for i,bin_radius_label in enumerate(bin_radius_labels):\n",
+    "    for i, bin_radius_label in enumerate(bin_radius_labels):\n",
     "        s_count2.add_data_point(\n",
-    "            cluster_shear, (survey_name, bin_z_label, bin_richness_label, bin_radius_label), profile[i])\n",
-    "    "
+    "            cluster_shear,\n",
+    "            (survey_name, bin_z_label, bin_richness_label, bin_radius_label),\n",
+    "            profile[i],\n",
+    "        )"
    ]
   },
   {
@@ -555,10 +570,34 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "DS0 = [s_count2.get_data_points(data_type='cluster_shear', tracers=('NC_mock_redshift_richness', 'bin_z_1', 'bin_rich_0', f'bin_radius_{i}'))[0].value for i in np.arange(len(radius_edges)-1)]\n",
-    "DS2 = [s_count2.get_data_points(data_type='cluster_shear', tracers=('NC_mock_redshift_richness', 'bin_z_1', 'bin_rich_2', f'bin_radius_{i}'))[0].value for i in np.arange(len(radius_edges)-1)]\n",
-    "r_arr = [s_count2.get_tracer(f'bin_radius_{i}').center for i in np.arange(len(radius_edges)-1)]\n",
-    "\n"
+    "DS0 = [\n",
+    "    s_count2.get_data_points(\n",
+    "        data_type=\"cluster_shear\",\n",
+    "        tracers=(\n",
+    "            \"NC_mock_redshift_richness\",\n",
+    "            \"bin_z_1\",\n",
+    "            \"bin_rich_0\",\n",
+    "            f\"bin_radius_{i}\",\n",
+    "        ),\n",
+    "    )[0].value\n",
+    "    for i in np.arange(len(radius_edges) - 1)\n",
+    "]\n",
+    "DS2 = [\n",
+    "    s_count2.get_data_points(\n",
+    "        data_type=\"cluster_shear\",\n",
+    "        tracers=(\n",
+    "            \"NC_mock_redshift_richness\",\n",
+    "            \"bin_z_1\",\n",
+    "            \"bin_rich_2\",\n",
+    "            f\"bin_radius_{i}\",\n",
+    "        ),\n",
+    "    )[0].value\n",
+    "    for i in np.arange(len(radius_edges) - 1)\n",
+    "]\n",
+    "r_arr = [\n",
+    "    s_count2.get_tracer(f\"bin_radius_{i}\").center\n",
+    "    for i in np.arange(len(radius_edges) - 1)\n",
+    "]"
    ]
   },
   {
@@ -568,19 +607,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plt.loglog(r_arr, DS0, label='bin_rich_0', marker='x')\n",
-    "plt.loglog(r_arr, DS2, label='bin_rich_2', marker='x')\n",
-    "plt.xlabel('R [Mpc]')\n",
-    "plt.ylabel('$\\Delta\\Sigma$ [M$_\\odot \\;$Mpc$^{-2}$]')\n",
+    "plt.loglog(r_arr, DS0, label=\"bin_rich_0\", marker=\"x\")\n",
+    "plt.loglog(r_arr, DS2, label=\"bin_rich_2\", marker=\"x\")\n",
+    "plt.xlabel(\"R [Mpc]\")\n",
+    "plt.ylabel(\"$\\Delta\\Sigma$ [M$_\\odot \\;$Mpc$^{-2}$]\")\n",
     "plt.legend()"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "wrk",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "wrk"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -592,7 +631,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.9"
+   "version": "3.10.8"
   }
  },
  "nbformat": 4,

--- a/examples/demo_sacc_for_clusters_N+M.ipynb
+++ b/examples/demo_sacc_for_clusters_N+M.ipynb
@@ -478,12 +478,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "bin_radius_list = []\n",
+    "bin_radius_labels = []\n",
     "radius_centers = []\n",
     "for i, radius_bin in enumerate(zip(radius_edges[:-1], radius_edges[1:])):\n",
     "    radius_lower, radius_upper = radius_bin\n",
-    "    bin_radius_list.append((radius_lower, radius_upper))\n",
-    "    radius_centers.append(radius_lower + (radius_upper - radius_lower)/2)\n",
+    "    radius_center = np.mean(radius_edges[i:i+1])\n",
+    "    radius_centers.append(radius_center)\n",
+    "    bin_radius_label = f\"bin_radius_{i}\"\n",
+    "    s_count2.add_tracer(\n",
+    "        \"bin_radius\", bin_radius_label, radius_lower, radius_upper, radius_center\n",
+    "    )\n",
+    "    bin_radius_labels.append(bin_radius_label)\n",
+    "    \n",
     "cluster_shear = sacc.standard_types.cluster_shear"
    ]
   },
@@ -503,17 +509,15 @@
    "outputs": [],
    "source": [
     "redshifts_masses_and_edges = zip(\n",
-    "    mean_z.flatten(), mean_logM.flatten(),itertools.product(bin_z_labels, bin_richness_labels)\n",
-    ")\n",
+    "    mean_z.flatten(), mean_logM.flatten(),itertools.product(bin_z_labels, bin_richness_labels))\n",
     "for redshift, log_mass, (bin_z_label, bin_richness_label) in redshifts_masses_and_edges:\n",
     "    mass = 10**log_mass\n",
     "    moo.set_mass(mass)\n",
     "    profile = moo.eval_excess_surface_density(radius_centers, redshift)\n",
-    "    for i in range(0,len(bin_radius_list)-1):\n",
+    "    for i,bin_radius_label in enumerate(bin_radius_labels):\n",
     "        s_count2.add_data_point(\n",
-    "            cluster_shear, (survey_name, bin_z_label, bin_richness_label), profile[i], radius_bin=bin_radius_list[i]\n",
-    "    )\n",
-    "        "
+    "            cluster_shear, (survey_name, bin_z_label, bin_richness_label, bin_radius_label), profile[i])\n",
+    "    "
    ]
   },
   {
@@ -551,21 +555,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "DS0_points = []\n",
-    "DS0_r_center = []\n",
-    "DS2_points = []\n",
-    "DS2_r_center = []\n",
-    "\n",
-    "DS0 = s_count2.get_data_points(data_type='cluster_shear', tracers=('NC_mock_redshift_richness', 'bin_z_1', 'bin_rich_0'))\n",
-    "DS2 = s_count2.get_data_points(data_type='cluster_shear', tracers=('NC_mock_redshift_richness', 'bin_z_1', 'bin_rich_2'))\n",
-    "for data_i in DS0:\n",
-    "    DS0_points.append(data_i.value)\n",
-    "    r_bin = data_i.get_tag('radius_bin')\n",
-    "    DS0_r_center.append(r_bin[0] + (r_bin[1] - r_bin[0])/2)\n",
-    "for data_i in DS2:\n",
-    "    DS2_points.append(data_i.value)\n",
-    "    r_bin = data_i.get_tag('radius_bin')\n",
-    "    DS2_r_center.append(r_bin[0] + (r_bin[1] - r_bin[0])/2)\n"
+    "DS0 = [s_count2.get_data_points(data_type='cluster_shear', tracers=('NC_mock_redshift_richness', 'bin_z_1', 'bin_rich_0', f'bin_radius_{i}'))[0].value for i in np.arange(len(radius_edges)-1)]\n",
+    "DS2 = [s_count2.get_data_points(data_type='cluster_shear', tracers=('NC_mock_redshift_richness', 'bin_z_1', 'bin_rich_2', f'bin_radius_{i}'))[0].value for i in np.arange(len(radius_edges)-1)]\n",
+    "r_arr = [s_count2.get_tracer(f'bin_radius_{i}').center for i in np.arange(len(radius_edges)-1)]\n",
+    "\n"
    ]
   },
   {
@@ -575,27 +568,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plt.loglog(DS0_r_center, DS0_points, label='bin_rich_0', marker='x')\n",
-    "plt.loglog(DS2_r_center, DS2_points, label='bin_rich_2', marker='x')\n",
+    "plt.loglog(r_arr, DS0, label='bin_rich_0', marker='x')\n",
+    "plt.loglog(r_arr, DS2, label='bin_rich_2', marker='x')\n",
     "plt.xlabel('R [Mpc]')\n",
     "plt.ylabel('$\\Delta\\Sigma$ [M$_\\odot \\;$Mpc$^{-2}$]')\n",
     "plt.legend()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "e927a990-36a8-482a-8f58-13fcd4aff2e2",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python (firecrown2.0)",
+   "display_name": "wrk",
    "language": "python",
-   "name": "firecrown"
+   "name": "wrk"
   },
   "language_info": {
    "codemirror_mode": {
@@ -607,7 +592,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.0"
+   "version": "3.10.9"
   }
  },
  "nbformat": 4,

--- a/sacc/data_types.py
+++ b/sacc/data_types.py
@@ -35,7 +35,7 @@ required_tags_concise = {
     "count": [],
     "cluster_counts": [],
     "cluster_mean_log_mass": [],
-    "cluster_shear": ["radius_bin"]
+    "cluster_shear": []
 }
 
 required_tags_verbose = {

--- a/sacc/tracers.py
+++ b/sacc/tracers.py
@@ -1077,6 +1077,48 @@ class BinRadiusTracer(BaseTracer, tracer_type="bin_radius"):  # type: ignore
 
         names = ["name", "quantity", "lower", "upper", "center"]
 
+        cols = [
+            [obj.name for obj in instance_list],
+            [obj.quantity for obj in instance_list],
+            [obj.lower for obj in instance_list],
+            [obj.upper for obj in instance_list],
+            [obj.center for obj in instance_list],
+        ]
+
+        table = Table(data=cols, names=names)
+        table.meta["SACCTYPE"] = "tracer"
+        table.meta["SACCCLSS"] = cls.tracer_type
+        table.meta["EXTNAME"] = f"tracer:{cls.tracer_type}"
+        return [table]
+
+    @classmethod
+    def from_tables(cls, table_list):
+        """Convert an astropy table into a dictionary of tracers
+
+        This is used when loading data from a file.
+        One tracer object is created for each "row" in each table.
+
+        :param table_list: List of astropy tables
+        :return: Dictionary of tracers
+        """
+        tracers = {}
+
+        for table in table_list:
+            for row in table:
+                name = row["name"]
+                quantity = row["quantity"]
+                lower = row["lower"]
+                upper = row["upper"]
+                center = row["center"]
+                tracers[name] = cls(
+                    name,
+                    quantity=quantity,
+                    lower=lower,
+                    upper=upper,
+                    center=center,
+                )
+        return tracers
+
 class SurveyTracer(BaseTracer, tracer_type="survey"):  # type: ignore
     """A tracer for the survey definition. It shall 
     be used to filter data related to a given survey

--- a/sacc/tracers.py
+++ b/sacc/tracers.py
@@ -1027,6 +1027,56 @@ class BinRichnessTracer(BaseTracer, tracer_type="bin_richness"):  # type: ignore
         return tracers
 
 
+class BinRadiusTracer(BaseTracer, tracer_type="bin_radius"):  # type: ignore
+    """A tracer for a single radial bin, e.g. when dealing with cluster shear profiles.
+    It gives the bin edges and the value of the bin "center". The latter would typically
+    be returned by CLMM and correspond to the average radius of the galaxies in that
+    radial bin. """
+
+    def __eq__(self, other) -> bool:
+        """Test for equality. If :python:`other` is not a
+        :python:`BinRadiusTracer`, then it is not equal to :python:`self`.
+        Otherwise, they are equal if names and the r-range and centers of the
+        bins, are equal."""
+        if not isinstance(other, BinRadiusTracer):
+            return False
+        return (
+            self.name == other.name
+            and self.lower == other.lower
+            and self.center == other.center
+            and self.upper == other.upper
+        )
+
+    def __init__(self, name: str, lower: float, upper: float, center: float, **kwargs):
+        """
+        Create a tracer corresponding to a single radial bin.
+
+        :param name: The name of the tracer
+        :param lower: The lower bound of the radius bin
+        :param upper: The upper bound of the radius bin
+        :param center: The value to use if a single point-estimate is needed.
+
+        Note that :python:`center` need not be the midpoint between
+        :python:`lower` and :python:`upper`'.
+        """
+        super().__init__(name, **kwargs)
+        self.lower = lower
+        self.upper = upper
+        self.center = center
+
+    @classmethod
+    def to_tables(cls, instance_list):
+        """Convert a list of BinRadiusTracers to a single astropy table
+
+        This is used when saving data to a file.
+        One table is generated with the information for all the tracers.
+
+        :param instance_list: List of tracer instances
+        :return: List with a single astropy table
+        """
+
+        names = ["name", "quantity", "lower", "upper", "center"]
+
 class SurveyTracer(BaseTracer, tracer_type="survey"):  # type: ignore
     """A tracer for the survey definition. It shall 
     be used to filter data related to a given survey

--- a/test/test_cluster_data_tracers.py
+++ b/test/test_cluster_data_tracers.py
@@ -7,6 +7,7 @@ from sacc.tracers import (
     BinZTracer,
     BinLogMTracer,
     BinRichnessTracer,
+    BinRadiusTracer,
     SurveyTracer,
 )
 
@@ -115,6 +116,59 @@ def test_binrichnesstracer_tables():
     assert len(d) == 2  # this list of tables recovers both BinRichnessTracers
     assert d["barney"] == a
     assert d["betty"] == b
+
+
+def test_make_binradiustracer():
+    tracer = BinRadiusTracer.make(
+        "bin_radius", name="pebbles", lower=1.0, center=2.0, upper=3.0
+    )
+    assert isinstance(tracer, BinRadiusTracer)
+    assert tracer.quantity == "generic"
+    assert tracer.name == "pebbles"
+    assert tracer.lower == 1.0
+    assert tracer.center == 2.0
+    assert tracer.upper == 3.0
+
+def test_binradiustracer_equality():
+    a = BinRadiusTracer.make(
+        "bin_radius", name="fred", lower=0.5, center=0.75, upper=1.0
+    )
+    b = BinRadiusTracer.make(
+        "bin_radius", name="fred", lower=0.5, center=0.75, upper=1.0
+    )
+    c = BinRadiusTracer.make(
+        "bin_radius", name="wilma", lower=0.5, center=0.75, upper=1.0
+    )
+    d = BinRadiusTracer.make(
+        "bin_radius", name="fred", lower=0.6, center=0.75, upper=1.0
+    )
+    e = BinRadiusTracer.make(
+        "bin_radius", name="fred", lower=0.5, center=0.8, upper=1.0
+    )
+    f = BinRadiusTracer.make(
+        "bin_radius", name="fred", lower=0.5, center=0.75, upper=1.1
+    )
+    assert a == b
+    assert a != "fred"
+    assert a != c
+    assert a != d
+    assert a != e
+    assert a != f
+
+
+def test_binradiustracer_tables():
+    a = BinRadiusTracer.make(
+        "bin_radius", name="pebbles", lower=1.0, center=2.0, upper=3.0
+    )
+    b = BinRadiusTracer.make(
+        "bin_radius", name="bambam", lower=3.0, center=4.0, upper=5.0
+    )
+    tables = BinRadiusTracer.to_tables([a, b])
+    assert len(tables) == 1
+    d = BinRadiusTracer.from_tables(tables)
+    assert len(d) == 2
+    assert d["pebbles"] == a
+    assert d["bambam"] == b
 
 
 def test_make_surveytracer():


### PR DESCRIPTION
This is addressing issue #93. We do need a radius tracer rather than a tag to compute the covariance between radial bin of the cluster shear profile. 
- radius traver added
- demo notebook updated to use radius tracer and not tags.