### PR TITLE
QPTracer Extension

### DIFF
--- a/sacc/tracers.py
+++ b/sacc/tracers.py
@@ -666,7 +666,7 @@ class QPNZTracer(BaseTracer, tracer_type='QPNZ'):
         The qp.ensemble in questions
     """
 
-    def __init__(self, name, ens, z, **kwargs):
+    def __init__(self, name, ens, z=None, **kwargs):
         """
         Create a tracer corresponding to a distribution in redshift n(z),
         for example of galaxies.
@@ -679,11 +679,6 @@ class QPNZTracer(BaseTracer, tracer_type='QPNZ'):
 
         ensemble: qp.Ensemble
             The qp.ensemble in questions
-        
-        z: array 
-            A suggested array of redshifts to evaluate the 
-            ensemble. Note that the QP ensemble does not assume
-            this grid.
 
         Returns
         -------
@@ -692,6 +687,12 @@ class QPNZTracer(BaseTracer, tracer_type='QPNZ'):
         """
         super().__init__(name, **kwargs)
         self.ensemble = ens
+        if z is None:
+            ens_meta = ens.metadata()
+            if 'bins' is in list(ens_meta.keys()):
+                z = ens_meta['bins']
+            else:
+                raise ValueError("No redshift bins provided or found in ensemble metadata")
         self.nz = np.mean(ens.pdf(z),axis=0)
         self.z = z
 

--- a/sacc/tracers.py
+++ b/sacc/tracers.py
@@ -689,13 +689,12 @@ class QPNZTracer(BaseTracer, tracer_type='QPNZ'):
         self.ensemble = ens
         ens_meta = ens.metadata()
         if z is None:
-            ens_meta = ens.metadata()
             if 'bins' in list(ens_meta.keys()):
-                z = ens_meta['bins']
                 z = ens_meta['bins'][0]
             else:
                 raise ValueError("No redshift bins provided or found in ensemble metadata")
-        self.nz = np.mean(ens.pdf(z), axis=0)
+        self.z = z
+        self.nz = np.mean(ens.pdf(self.z), axis=0)
 
     @classmethod
     def to_tables(cls, instance_list):

--- a/sacc/tracers.py
+++ b/sacc/tracers.py
@@ -687,14 +687,12 @@ class QPNZTracer(BaseTracer, tracer_type='QPNZ'):
         """
         super().__init__(name, **kwargs)
         self.ensemble = ens
-        if z is None:
-            ens_meta = ens.metadata()
-            if 'bins' in list(ens_meta.keys()):
-                z = ens_meta['bins'][0]
-            else:
-                raise ValueError("No redshift bins provided or found in ensemble metadata")
+        ens_meta = ens.metadata()
+        if (z is None) and ('bins' in ens_meta.keys()):
+            self.z = ens_meta['bins'][0]
+        else:
+            self.z = z
         self.nz = np.mean(ens.pdf(z),axis=0)
-        self.z = z
 
     @classmethod
     def to_tables(cls, instance_list):

--- a/sacc/tracers.py
+++ b/sacc/tracers.py
@@ -690,7 +690,7 @@ class QPNZTracer(BaseTracer, tracer_type='QPNZ'):
         if z is None:
             ens_meta = ens.metadata()
             if 'bins' in list(ens_meta.keys()):
-                z = ens_meta['bins']
+                z = ens_meta['bins'][0]
             else:
                 raise ValueError("No redshift bins provided or found in ensemble metadata")
         self.nz = np.mean(ens.pdf(z),axis=0)

--- a/sacc/tracers.py
+++ b/sacc/tracers.py
@@ -689,19 +689,13 @@ class QPNZTracer(BaseTracer, tracer_type='QPNZ'):
         self.ensemble = ens
         ens_meta = ens.metadata()
         if z is None:
-            if 'bins' in ens_meta.keys():
-                # Find z in the QP ensemble metadata
-                # Only true if the QP ensemble is a histogram
-                self.z = ens_meta['bins'][0]
-                self.nz = np.mean(ens.pdf(self.z), axis=0)
+            ens_meta = ens.metadata()
+            if 'bins' in list(ens_meta.keys()):
+                z = ens_meta['bins']
+                z = ens_meta['bins'][0]
             else:
-                # Set both to None if z cannot be found
-                self.z = z
-                self.nz = None
-        else:
-            # Normal mode
-            self.z = z
-            self.nz = np.mean(ens.pdf(self.z), axis=0)
+                raise ValueError("No redshift bins provided or found in ensemble metadata")
+        self.nz = np.mean(ens.pdf(z), axis=0)
 
     @classmethod
     def to_tables(cls, instance_list):

--- a/sacc/tracers.py
+++ b/sacc/tracers.py
@@ -652,7 +652,7 @@ class QPNZTracer(BaseTracer, tracer_type='QPNZ'):
     """
     A Tracer type for tomographic n(z) data represented as a `qp.Ensemble`
 
-    Takes a `qp.Ensemble` and a redshift array.
+    Takes a `qp.Ensemble` and optionally a redshift array.
 
     Requires the `qp` and `tables_io` packages to be installed.
 
@@ -679,6 +679,11 @@ class QPNZTracer(BaseTracer, tracer_type='QPNZ'):
 
         ensemble: qp.Ensemble
             The qp.ensemble in questions
+
+        z: array
+            Optional grid of redshift values at which to evaluate the ensemble.
+            If left as None then the ensemble metadata is checked for a grid.
+            If that is not present then no redshift grid is saved.
 
         Returns
         -------

--- a/sacc/tracers.py
+++ b/sacc/tracers.py
@@ -689,7 +689,7 @@ class QPNZTracer(BaseTracer, tracer_type='QPNZ'):
         self.ensemble = ens
         if z is None:
             ens_meta = ens.metadata()
-            if 'bins' is in list(ens_meta.keys()):
+            if 'bins' in list(ens_meta.keys()):
                 z = ens_meta['bins']
             else:
                 raise ValueError("No redshift bins provided or found in ensemble metadata")

--- a/sacc/tracers.py
+++ b/sacc/tracers.py
@@ -652,7 +652,7 @@ class QPNZTracer(BaseTracer, tracer_type='QPNZ'):
     """
     A Tracer type for tomographic n(z) data represented as a `qp.Ensemble`
 
-    Takes a `qp.Ensemble`
+    Takes a `qp.Ensemble` and a redshift array.
 
     Requires the `qp` and `tables_io` packages to be installed.
 
@@ -687,15 +687,15 @@ class QPNZTracer(BaseTracer, tracer_type='QPNZ'):
         """
         super().__init__(name, **kwargs)
         self.ensemble = ens
-        ens_meta = ens.metadata()
         if z is None:
+            ens_meta = ens.metadata()
             if 'bins' in list(ens_meta.keys()):
                 z = ens_meta['bins'][0]
             else:
                 raise ValueError("No redshift bins provided or found in ensemble metadata")
         self.z = z
-        self.nz = np.mean(ens.pdf(self.z), axis=0)
-
+        self.nz = np.mean(ens.pdf(self.z),axis=0)
+        
     @classmethod
     def to_tables(cls, instance_list):
         """Convert a list of NZTracers to a list of astropy tables
@@ -718,6 +718,15 @@ class QPNZTracer(BaseTracer, tracer_type='QPNZ'):
         tables = []
 
         for tracer in instance_list:
+            names = ['z', 'nz']
+            cols = [tracer.z, tracer.nz]
+            fid_table = Table(data=cols, names=names)
+            fid_table.meta['SACCTYPE'] = 'tracer'
+            fid_table.meta['SACCCLSS'] = cls.tracer_type
+            fid_table.meta['SACCNAME'] = tracer.name
+            fid_table.meta['SACCQTTY'] = tracer.quantity
+            fid_table.meta['EXTNAME'] = f'tracer:{cls.tracer_type}:{tracer.name}:fid'
+
             table_dict = tracer.ensemble.build_tables()
             ap_tables = convertToApTables(table_dict)
             data_table = ap_tables['data']
@@ -739,6 +748,7 @@ class QPNZTracer(BaseTracer, tracer_type='QPNZ'):
                 meta_table.meta['META_'+kk] = vv
             tables.append(data_table)
             tables.append(meta_table)
+            tables.append(fid_table)
             if ancil_table:
                 ancil_table.meta['SACCTYPE'] = 'tracer'
                 ancil_table.meta['SACCCLSS'] = cls.tracer_type
@@ -783,6 +793,8 @@ class QPNZTracer(BaseTracer, tracer_type='QPNZ'):
 
         for val in sorted_dict.values():
             meta_table = val['meta']
+            fid_table = val['fid']
+            z = fid_table['z']
             ensemble = qp.from_tables(val)
             name = meta_table.meta['SACCNAME']
             quantity = meta_table.meta.get('SACCQTTY', 'generic')
@@ -791,7 +803,7 @@ class QPNZTracer(BaseTracer, tracer_type='QPNZ'):
             for key, value in meta_table.meta.items():
                 if key.startswith("META_"):
                     metadata[key[5:]] = value
-            tracers[name] = cls(name, ensemble,
+            tracers[name] = cls(name, ensemble, z,
                                 quantity=quantity,
                                 metadata=metadata)
         return tracers

--- a/sacc/tracers.py
+++ b/sacc/tracers.py
@@ -696,7 +696,9 @@ class QPNZTracer(BaseTracer, tracer_type='QPNZ'):
                 # Default grid. Might be sub-optimal or 
                 # not needed at all depending on the analysis.
                 self.z = np.linspace(0, 3, 100)
-        self.nz = np.mean(ens.pdf(self.z),axis=0)
+        else:
+            self.z = z
+        self.nz = np.mean(ens.pdf(self.z), axis=0)
 
     @classmethod
     def to_tables(cls, instance_list):

--- a/sacc/tracers.py
+++ b/sacc/tracers.py
@@ -688,11 +688,15 @@ class QPNZTracer(BaseTracer, tracer_type='QPNZ'):
         super().__init__(name, **kwargs)
         self.ensemble = ens
         ens_meta = ens.metadata()
-        if (z is None) and ('bins' in ens_meta.keys()):
-            self.z = ens_meta['bins'][0]
-        else:
-            self.z = z
-        self.nz = np.mean(ens.pdf(z),axis=0)
+        if z is None:
+            if 'bins' in ens_meta.keys():
+                # Only true if QP ensemble is a histogram
+                self.z = ens_meta['bins'][0]
+            else:
+                # Default grid. Might be sub-optimal or 
+                # not needed at all depending on the analysis.
+                self.z = np.linspace(0, 3, 100)
+        self.nz = np.mean(ens.pdf(self.z),axis=0)
 
     @classmethod
     def to_tables(cls, instance_list):

--- a/sacc/tracers.py
+++ b/sacc/tracers.py
@@ -690,15 +690,18 @@ class QPNZTracer(BaseTracer, tracer_type='QPNZ'):
         ens_meta = ens.metadata()
         if z is None:
             if 'bins' in ens_meta.keys():
-                # Only true if QP ensemble is a histogram
+                # Find z in the QP ensemble metadata
+                # Only true if the QP ensemble is a histogram
                 self.z = ens_meta['bins'][0]
+                self.nz = np.mean(ens.pdf(self.z), axis=0)
             else:
-                # Default grid. Might be sub-optimal or 
-                # not needed at all depending on the analysis.
-                self.z = np.linspace(0, 3, 100)
+                # Set both to None if z cannot be found
+                self.z = z
+                self.nz = None
         else:
+            # Normal mode
             self.z = z
-        self.nz = np.mean(ens.pdf(self.z), axis=0)
+            self.nz = np.mean(ens.pdf(self.z), axis=0)
 
     @classmethod
     def to_tables(cls, instance_list):

--- a/test/test_sacc2.py
+++ b/test/test_sacc2.py
@@ -834,6 +834,7 @@ def test_qpnz_tracer():
     nz_qp_hist = qp.Ensemble(qp.hist, data=dict(bins=z, pdfs=np.ones(shape=(1, 100))))
 
     T1 = sacc.BaseTracer.make('QPNZ', 'tracer1', nz_qp_interp,
+                              z=z,
                               quantity='galaxy_density',
                               metadata=md1)
     T2 = sacc.BaseTracer.make('QPNZ', 'tracer2', nz_qp_hist,

--- a/test/test_sacc2.py
+++ b/test/test_sacc2.py
@@ -833,12 +833,10 @@ def test_qpnz_tracer():
     nz_qp_interp = qp.Ensemble(qp.interp, data=dict(xvals=z, yvals=np.ones(shape=(1, 101))))
     nz_qp_hist = qp.Ensemble(qp.hist, data=dict(bins=z, pdfs=np.ones(shape=(1, 100))))
 
-    T1 = sacc.BaseTracer.make('QPNZ', 'tracer1', nz_qp_interp,
-                              z=z,
+    T1 = sacc.BaseTracer.make('QPNZ', 'tracer1', nz_qp_interp, z,
                               quantity='galaxy_density',
                               metadata=md1)
-    T2 = sacc.BaseTracer.make('QPNZ', 'tracer2', nz_qp_hist,
-                              z=z,
+    T2 = sacc.BaseTracer.make('QPNZ', 'tracer2', nz_qp_hist, z,
                               quantity='galaxy_shear',
                               metadata=md2)
     assert T1.metadata == md1
@@ -861,7 +859,7 @@ def test_io_qp():
     nz = np.expand_dims((z-0.5)**2/0.1**2, 0)
     ens = qp.Ensemble(qp.interp, data=dict(xvals=z, yvals=nz))
     ens.set_ancil(dict(modes = ens.mode(z)))
-    s.add_tracer('QPNZ', 'source_0', ens, z=z)
+    s.add_tracer('QPNZ', 'source_0', ens, z)
 
     for i in range(20):
         ee = 0.1 * i

--- a/test/test_sacc2.py
+++ b/test/test_sacc2.py
@@ -833,10 +833,10 @@ def test_qpnz_tracer():
     nz_qp_interp = qp.Ensemble(qp.interp, data=dict(xvals=z, yvals=np.ones(shape=(1, 101))))
     nz_qp_hist = qp.Ensemble(qp.hist, data=dict(bins=z, pdfs=np.ones(shape=(1, 100))))
 
-    T1 = sacc.BaseTracer.make('QPNZ', 'tracer1', nz_qp_interp, z,
+    T1 = sacc.BaseTracer.make('QPNZ', 'tracer1', nz_qp_interp, z=z,
                               quantity='galaxy_density',
                               metadata=md1)
-    T2 = sacc.BaseTracer.make('QPNZ', 'tracer2', nz_qp_hist, z,
+    T2 = sacc.BaseTracer.make('QPNZ', 'tracer2', nz_qp_hist, z=z,
                               quantity='galaxy_shear',
                               metadata=md2)
     assert T1.metadata == md1
@@ -859,7 +859,7 @@ def test_io_qp():
     nz = np.expand_dims((z-0.5)**2/0.1**2, 0)
     ens = qp.Ensemble(qp.interp, data=dict(xvals=z, yvals=nz))
     ens.set_ancil(dict(modes = ens.mode(z)))
-    s.add_tracer('QPNZ', 'source_0', ens, z)
+    s.add_tracer('QPNZ', 'source_0', ens, z=z)
 
     for i in range(20):
         ee = 0.1 * i

--- a/test/test_sacc2.py
+++ b/test/test_sacc2.py
@@ -833,10 +833,10 @@ def test_qpnz_tracer():
     nz_qp_interp = qp.Ensemble(qp.interp, data=dict(xvals=z, yvals=np.ones(shape=(1, 101))))
     nz_qp_hist = qp.Ensemble(qp.hist, data=dict(bins=z, pdfs=np.ones(shape=(1, 100))))
 
-    T1 = sacc.BaseTracer.make('QPNZ', 'tracer1', nz_qp_interp, z=z,
+    T1 = sacc.BaseTracer.make('QPNZ', 'tracer1', nz_qp_interp, z,
                               quantity='galaxy_density',
                               metadata=md1)
-    T2 = sacc.BaseTracer.make('QPNZ', 'tracer2', nz_qp_hist, z=z,
+    T2 = sacc.BaseTracer.make('QPNZ', 'tracer2', nz_qp_hist, z,
                               quantity='galaxy_shear',
                               metadata=md2)
     assert T1.metadata == md1
@@ -859,7 +859,7 @@ def test_io_qp():
     nz = np.expand_dims((z-0.5)**2/0.1**2, 0)
     ens = qp.Ensemble(qp.interp, data=dict(xvals=z, yvals=nz))
     ens.set_ancil(dict(modes = ens.mode(z)))
-    s.add_tracer('QPNZ', 'source_0', ens, z=z)
+    s.add_tracer('QpnZ', 'source_0', ens, z)
 
     for i in range(20):
         ee = 0.1 * i

--- a/test/test_sacc2.py
+++ b/test/test_sacc2.py
@@ -836,7 +836,8 @@ def test_qpnz_tracer():
     T1 = sacc.BaseTracer.make('QPNZ', 'tracer1', nz_qp_interp,
                               quantity='galaxy_density',
                               metadata=md1)
-    T2 = sacc.BaseTracer.make('QPNZ', 'tracer2', nz_qp_hist, z,
+    T2 = sacc.BaseTracer.make('QPNZ', 'tracer2', nz_qp_hist,
+                              z=z,
                               quantity='galaxy_shear',
                               metadata=md2)
     assert T1.metadata == md1
@@ -859,7 +860,7 @@ def test_io_qp():
     nz = np.expand_dims((z-0.5)**2/0.1**2, 0)
     ens = qp.Ensemble(qp.interp, data=dict(xvals=z, yvals=nz))
     ens.set_ancil(dict(modes = ens.mode(z)))
-    s.add_tracer('QpnZ', 'source_0', ens, z)
+    s.add_tracer('QPNZ', 'source_0', ens, z=z)
 
     for i in range(20):
         ee = 0.1 * i

--- a/test/test_sacc2.py
+++ b/test/test_sacc2.py
@@ -833,7 +833,7 @@ def test_qpnz_tracer():
     nz_qp_interp = qp.Ensemble(qp.interp, data=dict(xvals=z, yvals=np.ones(shape=(1, 101))))
     nz_qp_hist = qp.Ensemble(qp.hist, data=dict(bins=z, pdfs=np.ones(shape=(1, 100))))
 
-    T1 = sacc.BaseTracer.make('QPNZ', 'tracer1', nz_qp_interp, z,
+    T1 = sacc.BaseTracer.make('QPNZ', 'tracer1', nz_qp_interp,
                               quantity='galaxy_density',
                               metadata=md1)
     T2 = sacc.BaseTracer.make('QPNZ', 'tracer2', nz_qp_hist, z,

--- a/test/test_sacc2.py
+++ b/test/test_sacc2.py
@@ -850,6 +850,15 @@ def test_qpnz_tracer():
     assert T1a.metadata == md1
     assert T2a.metadata == md2
 
+    # test version without saved z
+    T3 = sacc.BaseTracer.make('QPNZ', 'tracer3', nz_qp_interp, 
+                              quantity='galaxy_density',
+                              metadata=md1)
+    tables = sacc.BaseTracer.to_tables([T3])
+    D = sacc.BaseTracer.from_tables(tables)
+    assert D['tracer3'].z is None
+
+
 
 def test_io_qp():
     s = sacc.Sacc()


### PR DESCRIPTION
This PR adds the z and nz fields to the QPTracer in SACC.
This provides downstream packages with a suggested redshift array to evaluate the ensemble pdf when performing grid integration such as in CCL's tracers. 
Note that the QP ensemble does not assume this particular grid internally and the user can choose another grid any time. 