### PR TITLE
Stop re-ordering sacc objects when saving them

### DIFF
--- a/sacc/sacc.py
+++ b/sacc/sacc.py
@@ -904,7 +904,7 @@ class Sacc:
 
         # Put the data back in its original order, matching the
         # covariance.
-        data = [None for i in range(len(data))]
+        data = [None for i in range(len(data_unordered))]
         for i, d in zip(index, data_unordered):
             data[i] = d
 


### PR DESCRIPTION
This removes a annoying "feature" in which saved sacc objects were re-ordered into a canonical ordering. This was done to keep data points of the same type together and simplify saving, but meant that if you saved then loaded a sacc object it was differently ordered.

This saves the original ordering instead or re-ordering the data, so it is reconstructed when re-loaded.  As a nice side-effect this also means that covariance aren't converted into dense forms when saving, so it should also save some disk space when using block-diagonal covariances.

This could possibly break some existing workflows if people are assuming it's happening and then accessing data points directly instead of using the API. So it would require a major version number bump.  It's probably a good time to go to version 1.0 anyway, since the code is pretty mature now.