### PR TITLE
Convert numpy strings to str to avoid HDF5 warnings

### DIFF
--- a/sacc/sacc.py
+++ b/sacc/sacc.py
@@ -1029,6 +1029,13 @@ class Sacc:
         with h5py.File(filename, 'w') as f:
             used_names = {}
             for table in tables:
+                # Convert numpy string types to Python str to avoid HDF5 warnings
+                for key, value in list(table.meta.items()):
+                    if hasattr(value, 'item'):  # numpy scalar
+                        table.meta[key] = value.item()
+                    elif isinstance(value, str):
+                        table.meta[key] = str(value)
+
                 # Build a meaningful dataset name
                 typ = table.meta.get('SACCTYPE', 'unknown')
                 name = table.meta.get('SACCNAME', None)


### PR DESCRIPTION
Some existing FITS-form SACC file contain metadata that have type `numpy.str_`, rather than the Python `str`.
This causes problems when being written to HDF5.

This PR ensures that the metadata strings being written to HDF5 are `str` instances, not `numpy.str_`.