### PR TITLE
Added Delta sigma data type

### DIFF
--- a/examples/demo_sacc_for_clusters_N+M.ipynb
+++ b/examples/demo_sacc_for_clusters_N+M.ipynb
@@ -17,7 +17,7 @@
     "- generate a mock cluster catalog in richness-redshift bins. This is done using NumCosmo functionalities and requires Numcosmo v>=0.17\n",
     "- store all this information using the SACC framework. We present to cases:\n",
     "    - store **number counts and mean mass** in a single SACC file;\n",
-    "    - store **number counts and radial shear profile** in a single SACC file\n",
+    "    - store **number counts and radial shear profile ($\\Delta \\Sigma$)** in a single SACC file\n",
     "\n",
     "For the latter, in each richness-redshift bin, we generate a mock radial shear profile using CLMM. This is meant to correspond to the stacked shear profile in that bin.\n",
     "\n",
@@ -43,7 +43,6 @@
     "# This require Numcosmo v>=0.17\n",
     "from numcosmo_py import Nc\n",
     "from numcosmo_py import Ncm\n",
-    "\n",
     "import sacc as sacc\n",
     "\n",
     "os.environ[\n",
@@ -199,7 +198,7 @@
    "source": [
     "## SACC for number counts and mean mass in the $N_{\\rm richness} \\times N_z$ richness-redshift plane\n",
     "- count halos and compute mean mass in each bin, directly from the data generated at the previous step\n",
-    "- associate a \"mock\" shear profile, generated using CLMM from the mean mass in the bin, mock diagonal inter-radial bin covariance. Very rough/quick solution to get some \"shear profile data\".\n"
+    "- associate a \"mock\" shear profile $\\Delta \\Sigma$, generated using CLMM from the mean mass in the bin, mock diagonal inter-radial bin covariance. Very rough/quick solution to get some \"shear profile data\".\n"
    ]
   },
   {
@@ -382,7 +381,7 @@
     "tags": []
    },
    "source": [
-    "## SACC for number counts and shear profile in the $N_{\\rm richness} \\times N_z$ richness-redshift plane\n",
+    "## SACC for number counts and shear profile $\\Delta \\Sigma$ in the $N_{\\rm richness} \\times N_z$ richness-redshift plane\n",
     "\n",
     "\n",
     "Rather than saving the mean mass into SACC, one may want to save the 'stacked' shear profile in a richness-redshift bin. This possible as exemplified below. "
@@ -500,7 +499,7 @@
     "    )\n",
     "    bin_radius_labels.append(bin_radius_label)\n",
     "\n",
-    "cluster_shear = sacc.standard_types.cluster_shear"
+    "cluster_delta_sigma = sacc.standard_types.cluster_delta_sigma"
    ]
   },
   {
@@ -529,7 +528,7 @@
     "    profile = moo.eval_excess_surface_density(radius_centers, redshift)\n",
     "    for i, bin_radius_label in enumerate(bin_radius_labels):\n",
     "        s_count2.add_data_point(\n",
-    "            cluster_shear,\n",
+    "            cluster_delta_sigma,\n",
     "            (survey_name, bin_z_label, bin_richness_label, bin_radius_label),\n",
     "            profile[i],\n",
     "        )"
@@ -542,7 +541,7 @@
    "source": [
     "This is what the data now looks like:\n",
     "- 4 richness x 3 redshift bins \"number counts\" datapoints\n",
-    "- 4 richness x 3 redshift x 6 radius bins \"shear profile\" datapoints"
+    "- 4 richness x 3 redshift x 6 radius bins \"shear profile\" $\\Delta \\Sigma$ datapoints"
    ]
   },
   {
@@ -560,7 +559,7 @@
    "id": "b641b9c2-b261-4b80-a9ad-a4b22f5255ac",
    "metadata": {},
    "source": [
-    "### Santity check - plotting the shear profile for two richness bins, to check that the high richness bin as higher shear (i.e. ordering of data is OK)"
+    "### Santity check - plotting the shear profile $\\Delta \\Sigma$ for two richness bins, to check that the high richness bin as higher shear (i.e. ordering of data is OK)"
    ]
   },
   {
@@ -572,7 +571,7 @@
    "source": [
     "DS0 = [\n",
     "    s_count2.get_data_points(\n",
-    "        data_type=\"cluster_shear\",\n",
+    "        data_type=\"cluster_delta_sigma\",\n",
     "        tracers=(\n",
     "            \"NC_mock_redshift_richness\",\n",
     "            \"bin_z_1\",\n",
@@ -584,7 +583,7 @@
     "]\n",
     "DS2 = [\n",
     "    s_count2.get_data_points(\n",
-    "        data_type=\"cluster_shear\",\n",
+    "        data_type=\"cluster_delta_sigma\",\n",
     "        tracers=(\n",
     "            \"NC_mock_redshift_richness\",\n",
     "            \"bin_z_1\",\n",
@@ -617,9 +616,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python (firecrown20.0)",
    "language": "python",
-   "name": "python3"
+   "name": "firecrown_20"
   },
   "language_info": {
    "codemirror_mode": {
@@ -631,7 +630,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.8"
+   "version": "3.13.0"
   }
  },
  "nbformat": 4,

--- a/sacc/data_types.py
+++ b/sacc/data_types.py
@@ -35,7 +35,8 @@ required_tags_concise = {
     "count": [],
     "cluster_counts": [],
     "cluster_mean_log_mass": [],
-    "cluster_shear": []
+    "cluster_shear": [],
+    "cluster_delta_sigma": [],
 }
 
 required_tags_verbose = {


### PR DESCRIPTION
When computing the shear profiles for clusters, we can either choose between reduced shear, which might be viewed as the `cluster_shear` in the standard data types of sacc, or we can use \Delta \Sigma (the excess density surface mass). However there is no way to distinct between these data types and so far we have used the `cluster_shear` data type for  \Delta \Sigma. 

So this pull request is just to add this new `data_type` to sacc.