### PR TITLE
Remove mean attribute fron NZLinearUncertainty

### DIFF
--- a/sacc/tracer_uncertainty/nz.py
+++ b/sacc/tracer_uncertainty/nz.py
@@ -149,7 +149,7 @@ class NZLinearUncertainty(
     In this case to draw a sample of an n(z) you would generate a vector
     of standard normal variables and apply:
 
-    n_i -> n_i + mean + matrix @ normal_vector
+    n_i -> n_i + matrix @ normal_vector
     """
 
     storage_type = ONE_OBJECT_PER_TABLE
@@ -158,20 +158,18 @@ class NZLinearUncertainty(
             self,
             name,
             tracer_names,
-            mean, 
             matrix,
             ):
         """
         Initialize the NZLinearUncertainty object.
 
+        The mean attribute of the parent class is set to zero, so
+        it doesn't matter if you use it.
+
         Parameters
         ----------
         tracer_names : list of str
             List of tracer names to which the uncertainty applies.
-
-        mean: array-like
-            Intercept of the linear uncertainty model.
-            Can be interpreted as the mean of the parameters of the model.
 
         matrix: array-like
             Linear transformation matrix of the linear uncertainty model.
@@ -179,13 +177,15 @@ class NZLinearUncertainty(
             as well as the linear transformation of the parameters.
         """
 
+        mean = np.zeros(matrix.shape[0])
+
         super().__init__(
             name,
             tracer_names,
             mean,
             matrix,
             linear_transformation_type="linear_model"
-            )
+        )
 
 
 class NZShiftUncertainty(

--- a/sacc/tracer_uncertainty/nz.py
+++ b/sacc/tracer_uncertainty/nz.py
@@ -187,6 +187,32 @@ class NZLinearUncertainty(
             linear_transformation_type="linear_model"
         )
 
+    @classmethod
+    def from_table(cls, table):
+        """
+        Create an instance of one of the NZGaussianTracerUncertainty subclasses
+        from an astropy table.
+
+        This method is inherited by all subclasses, so the cls argument will be the
+        subclass that calls this method.
+
+        Parameters
+        ----------
+        table: astropy.table.Table
+            An astropy table containing the uncertainty data.
+
+        Returns
+        -------
+        instance: NZGaussianTracerUncertainty
+            An instance of a NZGaussianTracerUncertainty subclass.
+        """
+        # All the subclasses have the same table structure
+        transformation_type = table.meta["LINEAR_TRANSFORMATION_TYPE"]
+        cholesky = table[transformation_type]
+        tracer_names = [table.meta[f"TRACER_NAME_{i}"] for i in range(table.meta["N_TRACERS"])]
+        name = table.meta["SACCNAME"]
+        return cls(name, tracer_names, cholesky)
+
 
 class NZShiftUncertainty(
     BaseNZGaussianTracerUncertainty,

--- a/sacc/tracer_uncertainty/nz.py
+++ b/sacc/tracer_uncertainty/nz.py
@@ -78,7 +78,7 @@ class BaseNZGaussianTracerUncertainty(BaseTracerUncertainty):
             raise ValueError(f"Unknown transformation type: {linear_transformation_type}")
 
         # Params per tracer
-        self.nparams = self.linear_transformation.shape[0] // len(tracer_names)
+        self.nparams = self.linear_transformation.shape[1] // len(tracer_names)
         
 
     @classmethod

--- a/sacc/tracer_uncertainty/nz.py
+++ b/sacc/tracer_uncertainty/nz.py
@@ -177,7 +177,7 @@ class NZLinearUncertainty(
             as well as the linear transformation of the parameters.
         """
 
-        mean = np.zeros(matrix.shape[0])
+        mean = np.zeros(len(matrix))
 
         super().__init__(
             name,

--- a/sacc/tracer_uncertainty/nz.py
+++ b/sacc/tracer_uncertainty/nz.py
@@ -78,7 +78,7 @@ class BaseNZGaussianTracerUncertainty(BaseTracerUncertainty):
             raise ValueError(f"Unknown transformation type: {linear_transformation_type}")
 
         # Params per tracer
-        self.nparams = self.linear_transformation.shape[1] // len(tracer_names)
+        self.nparams = self.linear_transformation.shape[0] // len(tracer_names)
         
 
     @classmethod

--- a/test/test_sacc.py
+++ b/test/test_sacc.py
@@ -1206,9 +1206,8 @@ def test_nzlinear_uncertainty_saving():
     s.add_tracer('NZ', 'source2', z, nz2)
 
     tracer_names = ["source1", "source2"]
-    mean = [0.0, -0.001]
     sigma = [0.01, 0.02]
-    linear = sacc.NZLinearUncertainty("linear", tracer_names, mean, sigma)
+    linear = sacc.NZLinearUncertainty("linear", tracer_names, sigma)
     s.add_tracer_uncertainty_object(linear)
 
 
@@ -1223,7 +1222,7 @@ def test_nzlinear_uncertainty_saving():
     assert linear2.name == "linear"
     assert isinstance(linear2, sacc.NZLinearUncertainty)
     assert linear2.tracer_names == tracer_names
-    assert np.allclose(linear2.mean, mean)
+    assert np.allclose(linear2.mean, 0)
     assert np.allclose(linear2.linear_transformation, np.diag(sigma))
 
 def test_equality_mismatched_covariance(filled_sacc):


### PR DESCRIPTION
Right now the NZLinearUncertainty object stores a mean attribute.  But this is completely degenerate with the fiducial n(z) stored in the main Tracer objects, so is a potentially a cause for confusion - should the mean be in there or not? This change sets that mean to zero for this object.