### PR TITLE
Better handling for FITS and HDF5 file types

### DIFF
--- a/sacc/sacc.py
+++ b/sacc/sacc.py
@@ -14,7 +14,7 @@ import numpy as np
 from .tracers import BaseTracer
 from .windows import BandpowerWindow
 from .covariance import BaseCovariance, concatenate_covariances
-from .utils import unique_list
+from .utils import unique_list, detect_sacc_file_type
 from .data_types import standard_types, DataPoint
 from . import io
 
@@ -952,6 +952,16 @@ class Sacc:
         io.astropy_buffered_fits_write(filename, hdu_list)
 
     @classmethod
+    def load(cls, filename):
+        file_type = detect_sacc_file_type(filename)
+        if file_type == 'fits':
+            return cls.load_fits(filename)
+        elif file_type == 'hdf5':
+            return cls.load_hdf5(filename)
+        else:
+            raise ValueError(f"Unrecognized SACC file type for file {filename}")
+
+    @classmethod
     def load_fits(cls, filename):
         """
         Load a Sacc data set from a FITS file.
@@ -967,6 +977,10 @@ class Sacc:
         cov = None
         metadata = None
         fitsver = None
+
+        file_type = detect_sacc_file_type(filename)
+        if file_type != 'fits':
+            raise ValueError(f"File {filename} is of type {file_type}, not fits. Use Sacc.load or sacc.load_{file_type} to load it.")
 
         with fits.open(filename, mode="readonly") as f:
             tables = []
@@ -1092,6 +1106,11 @@ class Sacc:
         import h5py
         recovered_tables = []
         hdf5ver = None
+
+        file_type = detect_sacc_file_type(filename)
+        if file_type != 'hdf5':
+            raise ValueError(f"File {filename} is of type {file_type}, not hdf5. Use Sacc.load or sacc.load_{file_type} to load it.")
+
         with h5py.File(filename, 'r') as f:
             # Check version
             if 'sacc_hdf5_version' in f:

--- a/sacc/sacc.py
+++ b/sacc/sacc.py
@@ -980,7 +980,7 @@ class Sacc:
 
         file_type = detect_sacc_file_type(filename)
         if file_type != 'fits':
-            raise ValueError(f"File {filename} is of type {file_type}, not fits. Use Sacc.load or sacc.load_{file_type} to load it.")
+            raise ValueError(f"File {filename} is of type {file_type}, not fits. Use Sacc.load or Sacc.load_{file_type} to load it.")
 
         with fits.open(filename, mode="readonly") as f:
             tables = []
@@ -1109,7 +1109,7 @@ class Sacc:
 
         file_type = detect_sacc_file_type(filename)
         if file_type != 'hdf5':
-            raise ValueError(f"File {filename} is of type {file_type}, not hdf5. Use Sacc.load or sacc.load_{file_type} to load it.")
+            raise ValueError(f"File {filename} is of type {file_type}, not hdf5. Use Sacc.load or Sacc.load_{file_type} to load it.")
 
         with h5py.File(filename, 'r') as f:
             # Check version

--- a/sacc/utils.py
+++ b/sacc/utils.py
@@ -210,3 +210,33 @@ def numpy_to_vanilla(x):
     elif type(x) == np.bool_:
         x = bool(x)
     return x
+
+def detect_sacc_file_type(filename):
+    """
+    Detect the SACC file type based on the filename extension,
+    or, if that is ambigious, based on markers at the start of the file.
+
+    Parameters
+    ----------
+    filename : str
+        The name of the file to check.
+
+    Returns
+    -------
+    str
+        The detected file type ('fits', 'hdf5', or 'unknown').
+    """
+    if filename.endswith('.fits'):
+        return 'fits'
+    elif filename.endswith('.hdf5'):
+        return 'hdf5'
+
+    with open(filename, 'rb') as f:
+        marker = f.read(8)
+        if marker ==  b"\x89HDF\r\n\x1a\n":
+            return 'hdf5'
+        elif marker[:6] == b"SIMPLE":
+            return 'fits'
+
+    raise ValueError(f"Could not detect file type of {filename} from filename or file content.")
+

--- a/sacc/utils.py
+++ b/sacc/utils.py
@@ -214,7 +214,7 @@ def numpy_to_vanilla(x):
 def detect_sacc_file_type(filename):
     """
     Detect the SACC file type based on the filename extension,
-    or, if that is ambigious, based on markers at the start of the file.
+    or, if that is ambiguous, based on markers at the start of the file.
 
     Parameters
     ----------
@@ -224,7 +224,12 @@ def detect_sacc_file_type(filename):
     Returns
     -------
     str
-        The detected file type ('fits', 'hdf5', or 'unknown').
+        The detected file type ('fits' or 'hdf5').
+
+    Raises
+    ------
+    ValueError
+        If the file type cannot be detected from the filename or file content.
     """
     if filename.endswith('.fits'):
         return 'fits'

--- a/test/test_load_fits.py
+++ b/test/test_load_fits.py
@@ -68,7 +68,7 @@ def test_load_any():
 
     s.save_fits(generic_filename, overwrite=True)
     assert sacc.utils.detect_sacc_file_type(generic_filename) == "fits"
-    with pytest.raises(ValueError, match="is of type fits, not hdf5\. Use Sacc\.load or Sacc\.load_fits to load it"):
+    with pytest.raises(ValueError, match=r"is of type fits, not hdf5\. Use Sacc\.load or Sacc\.load_fits to load it"):
         sacc.Sacc.load_hdf5(generic_filename)
 
     # Load with the generic method, which should detect the format
@@ -77,7 +77,7 @@ def test_load_any():
 
     s.save_hdf5(generic_filename, overwrite=True)
     assert sacc.utils.detect_sacc_file_type(generic_filename) == "hdf5"
-    with pytest.raises(ValueError, match="is of type hdf5, not fits\. Use Sacc\.load or Sacc\.load_hdf5 to load it"):
+    with pytest.raises(ValueError, match=r"is of type hdf5, not fits\. Use Sacc\.load or Sacc\.load_hdf5 to load it"):
         sacc.Sacc.load_fits(generic_filename)
 
     # should be able to load from either format with Sacc.load

--- a/test/test_load_fits.py
+++ b/test/test_load_fits.py
@@ -90,3 +90,38 @@ def test_load_any():
     assert t1 == t1a
     # and be equal to the original data
     assert t1 == s
+
+
+def test_detect_sacc_file_type_unknown(tmp_path):
+    unknown_file = tmp_path / "unknown.sacc"
+    unknown_file.write_bytes(b"not a sacc file")
+
+    with pytest.raises(
+        ValueError,
+        match=r"Could not detect file type of .+ from filename or file content",
+    ):
+        sacc.utils.detect_sacc_file_type(str(unknown_file))
+
+
+def test_sacc_load_unknown_file(tmp_path):
+    unknown_file = tmp_path / "unknown.sacc"
+    unknown_file.write_bytes(b"not a sacc file")
+
+    with pytest.raises(ValueError, match=r"Could not detect file type"):
+        sacc.Sacc.load(str(unknown_file))
+
+
+def test_sacc_load_unrecognized_file_type(monkeypatch, tmp_path):
+    unknown_file = tmp_path / "unknown.sacc"
+    unknown_file.write_bytes(b"anything")
+
+    def fake_detect(filename):
+        return "json"
+
+    monkeypatch.setattr(sacc.sacc, "detect_sacc_file_type", fake_detect)
+
+    with pytest.raises(
+        ValueError,
+        match=f"Unrecognized SACC file type for file {unknown_file}",
+    ):
+        sacc.Sacc.load(str(unknown_file))

--- a/test/test_load_fits.py
+++ b/test/test_load_fits.py
@@ -2,6 +2,8 @@
 
 import numpy as np
 import sacc
+import pytest
+
 
 def create_simple_sacc():
     # Create a new Sacc object
@@ -38,10 +40,53 @@ def create_simple_sacc():
 
     # --- 4️⃣ Save the SACC file ---
     s.to_canonical_order()
-    s.save_fits("test/data/simple_mock_clusters.sacc", overwrite=True)
+    return s
 
-    print(f"SACC file saved with {ndata} data points: test/data/simple_mock_clusters.sacc")
 
 def test_bool_numpy_error():
-    create_simple_sacc()
+    s = create_simple_sacc()
+    s.save_fits("test/data/simple_mock_clusters.sacc", overwrite=True)
+    print(f"SACC file saved with {len(s.data)} data points: test/data/simple_mock_clusters.sacc")
     t2 = sacc.Sacc.load_fits("test/data/simple_mock_clusters.sacc")
+
+
+def test_load_any():
+    s = create_simple_sacc()
+    fits_filename = "test/data/simple_mock_clusters.fits"
+    hdf5_filename = "test/data/simple_mock_clusters.hdf5"
+    generic_filename = "test/data/simple_mock_clusters.sacc"
+
+    # Check the generic loader works when the file extension is explicitly .fits
+    s.save_fits(fits_filename, overwrite=True)
+    assert sacc.utils.detect_sacc_file_type(fits_filename) == "fits"
+    sacc.Sacc.load_fits(fits_filename)
+
+    # and the same check for HDF5
+    s.save_hdf5(hdf5_filename, overwrite=True)
+    assert sacc.utils.detect_sacc_file_type(hdf5_filename) == "hdf5"
+    sacc.Sacc.load_hdf5(hdf5_filename)
+
+    s.save_fits(generic_filename, overwrite=True)
+    assert sacc.utils.detect_sacc_file_type(generic_filename) == "fits"
+    with pytest.raises(ValueError, match="is of type fits, not hdf5. Use Sacc.load or sacc.load_fits to load it"):
+        sacc.Sacc.load_hdf5(generic_filename)
+
+    # Load with the generic method, which should detect the format
+    t1 = sacc.Sacc.load(generic_filename)
+    t1a = sacc.Sacc.load_fits(generic_filename)
+
+    s.save_hdf5(generic_filename, overwrite=True)
+    assert sacc.utils.detect_sacc_file_type(generic_filename) == "hdf5"
+    with pytest.raises(ValueError, match="is of type hdf5, not fits. Use Sacc.load or sacc.load_hdf5 to load it"):
+        sacc.Sacc.load_fits(generic_filename)
+
+    # should be able to load from either format with Sacc.load
+    t2 = sacc.Sacc.load(generic_filename)
+    t2a = sacc.Sacc.load_hdf5(generic_filename)
+
+    # All the loaded objects should be identical
+    assert t1 == t2
+    assert t1a == t2a
+    assert t1 == t1a
+    # and be equal to the original data
+    assert t1 == s

--- a/test/test_load_fits.py
+++ b/test/test_load_fits.py
@@ -68,7 +68,7 @@ def test_load_any():
 
     s.save_fits(generic_filename, overwrite=True)
     assert sacc.utils.detect_sacc_file_type(generic_filename) == "fits"
-    with pytest.raises(ValueError, match="is of type fits, not hdf5. Use Sacc.load or sacc.load_fits to load it"):
+    with pytest.raises(ValueError, match="is of type fits, not hdf5\. Use Sacc\.load or Sacc\.load_fits to load it"):
         sacc.Sacc.load_hdf5(generic_filename)
 
     # Load with the generic method, which should detect the format
@@ -77,7 +77,7 @@ def test_load_any():
 
     s.save_hdf5(generic_filename, overwrite=True)
     assert sacc.utils.detect_sacc_file_type(generic_filename) == "hdf5"
-    with pytest.raises(ValueError, match="is of type hdf5, not fits. Use Sacc.load or sacc.load_hdf5 to load it"):
+    with pytest.raises(ValueError, match="is of type hdf5, not fits\. Use Sacc\.load or Sacc\.load_hdf5 to load it"):
         sacc.Sacc.load_fits(generic_filename)
 
     # should be able to load from either format with Sacc.load


### PR DESCRIPTION
We recently added HDF5 files, but if the file suffix used was .sacc that could lead to confusion about which loader to use. This change adds a generic Sacc.load method that detects which file type to read, and also adds checks in the load_fits and load_hdf5 methods to provide better error messages if the wrong one is used.